### PR TITLE
Opinionated changes to required install commands

### DIFF
--- a/Language Orb Standardization.md
+++ b/Language Orb Standardization.md
@@ -26,22 +26,13 @@ This document serves to define the standard schema/design for all language based
     *   Use cimg [[dockerhub](https://hub.docker.com/u/cimg)]
     *   Executor must have language tools pre-installed.
 *   **Commands:**
-    *   install
-        *   Description: Install / manage version of language
-        *   Set version
-        *   Check for existence before installation, skip if installed.
-        *   Attempt to install binary directly
-            *   Otherwise: install using most popular version manager.
     *   install-deps
         *   Description: Standard command for all language orbs to install dependencies
         *   Parameterize the package manager, with the most popular as the default
             *   Ensure the selected package manager (and version) is currently installed.
-        *   
-    *   install-<packagemanager>
-        *   Description: Install popular package manager(s). Name command with name of package manager.
-        *   Set version 
-            *   Use latest as default, so users will not run into issues when they change package manager by referencing an invalid version if they do not select one.
-        *   Check for existence before installation, skip if installed.
+    *   test
+        * must be wrapped inside restore and save cache commands
+        * Calls language or frameworks's common testing tool(s)
     *   save-cache
         *   Automatically save cache for the selected language
         *   Parameterize path


### PR DESCRIPTION
Package managers and languages should come from the underlying image, not be a runtime concern.  If users deviate from the common tooling, they can use pre-steps or customized jobs to handle installs.